### PR TITLE
refactor: change to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,39 +56,39 @@ D/Lifecykle: MainFragment ⇀ onStop
 ## Configuration
 
 ### Logging mechanism
-By default LogLifecykle will output to `Log.d` with a tag of `Lifecykle`, to override this behaviour pass a callback into the `initialize` block.
+By default LogLifecykle will output to `Log.d` with a tag of `Lifecykle`, to override this behaviour pass an implementation into the `LifecykleLog.logHandler`.
 
 ```kotlin
-LifecykleLog.initialize(this) { clazz, lifecycleEvent ->
-    Log.e(clazz, lifecycleEvent)
+LifecykleLog.logHandler = LogHandler { clazz, lifecycleEvent ->
+    Log.e(clazz, lifecycleEvent) 
 }
 ```
 
 This can allow you to use other logging frameworks such as Timber.
 
 ```kotlin
-LifecykleLog.initialize(this) { clazz, lifecycleEvent ->
+LifecykleLog.logHandler = LogHandler { clazz, lifecycleEvent ->
     Timber.i("$clazz -> $lifecycleEvent")
 }
 ```
 
 ### Lifecycle methods
-To customise which lifecycle methods are logged out, an enum is available to pass into either the `initalize` block, or can be used with the annotation.
+To customise which lifecycle methods are logged out, an array of the `LifecycleEvent` enum can be passed into  `LifecykleLog.logEvents`, this can also be done with the `@LogLifecykle` annotation.
 
 ```kotlin
-LifecykleLog.initialize(
-    this, 
-    defaultLifecycleEvents = arrayOf(LifecycleEvent.ON_CREATE, LifecycleEvent.ON_DESTROY)
+LifecykleLog.logEvents = arrayOf(
+    LifecycleEvent.ON_CREATE, 
+    LifecycleEvent.ON_DESTROY
 )
 
-@LogLifecykle(overrideLifecycleEvents = [LifecycleEvent.ON_START])
+@LogLifecykle(overrideLogEvents = [LifecycleEvent.ON_START])
 class MainActivity : AppCompatActivity() {
 
-@LogLifecykle(overrideLifecycleEvents = [LifecycleEvent.ON_ACTIVITY_CREATED, LifecycleEvent.ON_ATTACH])
+@LogLifecykle(overrideLogEvents = [LifecycleEvent.ON_ACTIVITY_CREATED, LifecycleEvent.ON_ATTACH])
 class MainFragment : Fragment() {
 ```
-If `defaultLifecycleEvents` is provided to the `initalize` call then it will override the defaults.  
-If `overrideLifecycleEvents` is provided on the annotation, **only** the methods that are provided in this will be logged out.
+If `logEvents` is provided to the `LifecykleLog` then it will override the defaults.  
+If `overrideLogEvents` is provided on the annotation, **only** the methods that are provided in this will be logged out.
 
 ### Class name
 To customise the class name that is logged out, a new name can be provided to the annotation.
@@ -108,6 +108,8 @@ _For more examples and usage, please refer to the [sample](https://github.com/Ch
 
 ## Release History
 
+* 2.0.0
+	* Refactor to be easier to configure, stripping the initialize method down to just taking the Application object.
 * 1.0.0
     * Initial version
 

--- a/lifecyklelog-sample/src/main/java/com/chesire/lifecyklelogsample/ApplicationOverride.kt
+++ b/lifecyklelog-sample/src/main/java/com/chesire/lifecyklelogsample/ApplicationOverride.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.util.Log
 import com.chesire.lifecyklelog.LifecycleEvent
 import com.chesire.lifecyklelog.LifecykleLog
+import com.chesire.lifecyklelog.LogHandler
 
 /**
  * [Application] to show how to use [LifecykleLog].
@@ -20,9 +21,7 @@ class ApplicationOverride : Application() {
                 LifecycleEvent.ON_ATTACH,
                 LifecycleEvent.ON_DESTROY
             )
-            logHandler = { clazz, lifecycleEvent ->
-                Log.i(clazz, lifecycleEvent)
-            }
+            logHandler = LogHandler { clazz, lifecycleEvent -> Log.i(clazz, lifecycleEvent) }
         }
     }
 }

--- a/lifecyklelog-sample/src/main/java/com/chesire/lifecyklelogsample/ApplicationOverride.kt
+++ b/lifecyklelog-sample/src/main/java/com/chesire/lifecyklelogsample/ApplicationOverride.kt
@@ -12,15 +12,17 @@ import com.chesire.lifecyklelog.LifecykleLog
 class ApplicationOverride : Application() {
     override fun onCreate() {
         super.onCreate()
-        LifecykleLog.initialize(
-            this,
-            defaultLifecycleEvents = arrayOf(
+
+        LifecykleLog.apply {
+            initialize(this@ApplicationOverride)
+            logEvents = arrayOf(
                 LifecycleEvent.ON_CREATE,
                 LifecycleEvent.ON_ATTACH,
                 LifecycleEvent.ON_DESTROY
             )
-        ) { clazz, lifecycleEvent ->
-            Log.i(clazz, lifecycleEvent)
+            logHandler = { clazz, lifecycleEvent ->
+                Log.i(clazz, lifecycleEvent)
+            }
         }
     }
 }

--- a/lifecyklelog-sample/src/main/java/com/chesire/lifecyklelogsample/JApplicationOverride.java
+++ b/lifecyklelog-sample/src/main/java/com/chesire/lifecyklelogsample/JApplicationOverride.java
@@ -1,0 +1,34 @@
+package com.chesire.lifecyklelogsample;
+
+import android.annotation.SuppressLint;
+import android.app.Application;
+import android.util.Log;
+
+import com.chesire.lifecyklelog.LifecycleEvent;
+import com.chesire.lifecyklelog.LifecykleLog;
+import com.chesire.lifecyklelog.LogHandler;
+
+/**
+ * {@link Application} class to show how to use {@link LifecykleLog} in Java.
+ */
+@SuppressLint("Registered")
+public class JApplicationOverride extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        LifecycleEvent[] events = {
+                LifecycleEvent.ON_CREATE,
+                LifecycleEvent.ON_ATTACH,
+                LifecycleEvent.ON_DESTROY
+        };
+        LifecykleLog.INSTANCE.initialize(this);
+        LifecykleLog.INSTANCE.setLogEvents(events);
+        LifecykleLog.INSTANCE.setLogHandler(new LogHandler() {
+            @Override
+            public void logLifecycleMethod(String clazz, String lifecycleEvent) {
+                Log.i(clazz, lifecycleEvent);
+            }
+        });
+    }
+}

--- a/lifecyklelog-sample/src/main/java/com/chesire/lifecyklelogsample/MainFragment.kt
+++ b/lifecyklelog-sample/src/main/java/com/chesire/lifecyklelogsample/MainFragment.kt
@@ -12,7 +12,7 @@ import com.chesire.lifecyklelog.LogLifecykle
  * [Fragment] to show how to use [LogLifecykle].
  */
 @LogLifecykle(
-    overrideLifecycleEvents = [
+    overrideLogEvents = [
         LifecycleEvent.ON_ACTIVITY_CREATED,
         LifecycleEvent.ON_ATTACH,
         LifecycleEvent.ON_DETACH,

--- a/lifecyklelog/src/main/java/com/chesire/lifecyklelog/LifecykleLog.kt
+++ b/lifecyklelog/src/main/java/com/chesire/lifecyklelog/LifecykleLog.kt
@@ -42,9 +42,9 @@ object LifecykleLog {
 
     /**
      * Callback to execute when a lifecycle is logged, override this to change how logging occurs.
-     * By default `Log.d` will be used.
+     * If this is null then it will default to logging using `Log.d`.
      */
-    var logHandler: ((String, String) -> Unit)? = null
+    var logHandler: LogHandler? = null
 
     /**
      * Initializes the [LifecykleLog] with the given [app].
@@ -212,6 +212,8 @@ object LifecykleLog {
     }
 
     private fun executeLog(statement: String, lifecycleEvent: String) {
-        logHandler?.invoke(statement, lifecycleEvent) ?: Log.d("Lifecykle", "$statement ⇀ $lifecycleEvent")
+        logHandler
+            ?.logLifecycleMethod(statement, lifecycleEvent)
+            ?: Log.d("Lifecykle", "$statement ⇀ $lifecycleEvent")
     }
 }

--- a/lifecyklelog/src/main/java/com/chesire/lifecyklelog/LifecykleLog.kt
+++ b/lifecyklelog/src/main/java/com/chesire/lifecyklelog/LifecykleLog.kt
@@ -17,40 +17,41 @@ import com.chesire.lifecyklelog.LifecykleLog.initialize
  */
 object LifecykleLog {
     private val annotationClass = LogLifecykle::class.java
-    private lateinit var logLifecycleEvents: Array<LifecycleEvent>
-    private var log: ((String, String) -> Unit)? = null
+
+    /**
+     * An array of lifecycle events to provide logging for.
+     * If not overridden then will use the defaults of [LifecycleEvent.ON_ATTACH],
+     * [LifecycleEvent.ON_CREATE], [LifecycleEvent.ON_CREATE_VIEW],
+     * [LifecycleEvent.ON_ACTIVITY_CREATED], [LifecycleEvent.ON_START],
+     * [LifecycleEvent.ON_RESUME], [LifecycleEvent.ON_PAUSE], [LifecycleEvent.ON_STOP],
+     * [LifecycleEvent.ON_DESTROY_VIEW], [LifecycleEvent.ON_DESTROY], & [LifecycleEvent.ON_DETACH].
+     */
+    var logEvents: Array<LifecycleEvent> = arrayOf(
+        LifecycleEvent.ON_ATTACH,
+        LifecycleEvent.ON_CREATE,
+        LifecycleEvent.ON_CREATE_VIEW,
+        LifecycleEvent.ON_ACTIVITY_CREATED,
+        LifecycleEvent.ON_START,
+        LifecycleEvent.ON_RESUME,
+        LifecycleEvent.ON_PAUSE,
+        LifecycleEvent.ON_STOP,
+        LifecycleEvent.ON_DESTROY_VIEW,
+        LifecycleEvent.ON_DESTROY,
+        LifecycleEvent.ON_DETACH
+    )
+
+    /**
+     * Callback to execute when a lifecycle is logged, override this to change how logging occurs.
+     * By default `Log.d` will be used.
+     */
+    var logHandler: ((String, String) -> Unit)? = null
 
     /**
      * Initializes the [LifecykleLog] with the given [app].
      * Using [app] it will hook into all [Activity] life cycles, and from there the [Fragment]
      * life cycles.
-     *
-     * @param defaultLifecycleEvents An array of lifecycle events to provide logging for, if none
-     * are passed in some defaults are used.
-     * @param logExecution method to execute when a lifecycle is logged, using this a different log
-     * can be used. If nothing is passed in than `Log.d` will be used instead.
      */
-    fun initialize(
-        app: Application,
-        defaultLifecycleEvents: Array<LifecycleEvent> = arrayOf(
-            LifecycleEvent.ON_ATTACH,
-            LifecycleEvent.ON_CREATE,
-            LifecycleEvent.ON_CREATE_VIEW,
-            LifecycleEvent.ON_ACTIVITY_CREATED,
-            LifecycleEvent.ON_START,
-            LifecycleEvent.ON_RESUME,
-            LifecycleEvent.ON_PAUSE,
-            LifecycleEvent.ON_STOP,
-            LifecycleEvent.ON_DESTROY_VIEW,
-            LifecycleEvent.ON_DESTROY,
-            LifecycleEvent.ON_DETACH
-        ),
-        logExecution: ((String, String) -> Unit)? = null
-    ) {
-        logLifecycleEvents = defaultLifecycleEvents
-        log = logExecution
-        setupActivity(app)
-    }
+    fun initialize(app: Application) = setupActivity(app)
 
     private fun setupActivity(app: Application) =
         app.registerActivityLifecycleCallbacks(activityCallbacks)
@@ -195,7 +196,7 @@ object LifecykleLog {
                 }
             } else {
                 // Check the defaults
-                if (!logLifecycleEvents.contains(lifecycleEvent)) {
+                if (!logEvents.contains(lifecycleEvent)) {
                     // Defaults doesn't contain this event
                     return
                 }
@@ -211,6 +212,6 @@ object LifecykleLog {
     }
 
     private fun executeLog(statement: String, lifecycleEvent: String) {
-        log?.invoke(statement, lifecycleEvent) ?: Log.d("Lifecykle", "$statement ⇀ $lifecycleEvent")
+        logHandler?.invoke(statement, lifecycleEvent) ?: Log.d("Lifecykle", "$statement ⇀ $lifecycleEvent")
     }
 }

--- a/lifecyklelog/src/main/java/com/chesire/lifecyklelog/LifecykleLog.kt
+++ b/lifecyklelog/src/main/java/com/chesire/lifecyklelog/LifecykleLog.kt
@@ -188,9 +188,9 @@ object LifecykleLog {
 
     private fun <T : Any> logLifecycle(clazz: T, lifecycleEvent: LifecycleEvent) {
         clazz::class.java.getAnnotation(annotationClass)?.let { annotation ->
-            if (annotation.overrideLifecycleEvents.isNotEmpty()) {
+            if (annotation.overrideLogEvents.isNotEmpty()) {
                 // Overridden the defaults, check if should perform logging
-                if (!annotation.overrideLifecycleEvents.contains(lifecycleEvent)) {
+                if (!annotation.overrideLogEvents.contains(lifecycleEvent)) {
                     // Don't perform logging as this lifecycle event is not wanted
                     return
                 }

--- a/lifecyklelog/src/main/java/com/chesire/lifecyklelog/LogHandler.java
+++ b/lifecyklelog/src/main/java/com/chesire/lifecyklelog/LogHandler.java
@@ -1,0 +1,14 @@
+package com.chesire.lifecyklelog;
+
+/**
+ * Handles logging out lifecycle methods.
+ */
+public interface LogHandler {
+    /**
+     * Executed when a lifecycle method requires logging.
+     *
+     * @param clazz          string representation of the class that the lifecycle event occurred on.
+     * @param lifecycleEvent string representation of the lifecycle event that occurred.
+     */
+    void logLifecycleMethod(String clazz, String lifecycleEvent);
+}

--- a/lifecyklelog/src/main/java/com/chesire/lifecyklelog/LogLifecykle.kt
+++ b/lifecyklelog/src/main/java/com/chesire/lifecyklelog/LogLifecykle.kt
@@ -9,14 +9,13 @@ import androidx.fragment.app.Fragment
  * If the [className] is provided, this is the name that will be used for this class,
  * use either the name of the class or something descriptive to see in the logs. If nothing is
  * provided then [LifecykleLog] will attempt to get it by inspecting the class.
- * By default all lifecycle methods that were initialized in [LifecykleLog] will be logged out,
- * if the [overrideLifecycleEvents] is provided then only the methods provided in there will be
- * logged out.
+ * By default all lifecycle methods that were provided in [LifecykleLog] will be logged out,
+ * if [overrideLogEvents] is provided then only the methods provided to it will be logged out.
  */
 @MustBeDocumented
 @Retention
 @Target(AnnotationTarget.CLASS)
 annotation class LogLifecykle(
     val className: String = "",
-    val overrideLifecycleEvents: Array<LifecycleEvent> = []
+    val overrideLogEvents: Array<LifecycleEvent> = []
 )


### PR DESCRIPTION
Change from setting everything up via the `initialize` method, instead allow all the settings to be changed afterwards using properties.