### PR TITLE
feat: add information for about libraries support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,13 +50,12 @@ detekt {
 }
 
 ext.getVersionTag = {
-        def stdout
-        stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'describe', '--tags'
-            standardOutput = stdout
-        }
-        def longTag = stdout.toString().trim()
-
-        return longTag.substring(longTag.indexOf('/') + 1, longTag.indexOf('-'))
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags', '--always'
+        standardOutput = stdout
     }
+    def longTag = stdout.toString().trim()
+
+    return longTag.substring(longTag.indexOf('/') + 1, longTag.indexOf('-'))
+}

--- a/build.gradle
+++ b/build.gradle
@@ -48,3 +48,15 @@ detekt {
         }
     }
 }
+
+ext.getVersionTag = {
+        def stdout
+        stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'describe', '--tags'
+            standardOutput = stdout
+        }
+        def longTag = stdout.toString().trim()
+
+        return longTag.substring(longTag.indexOf('/') + 1, longTag.indexOf('-'))
+    }

--- a/lifecyklelog/build.gradle
+++ b/lifecyklelog/build.gradle
@@ -5,19 +5,6 @@ apply from: 'bintray.gradle'
 apply from: '../jacoco.gradle'
 apply from: '../ktlint.gradle'
 
-def getVersionTag = {
-    def stdout
-    stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'describe', '--tags'
-        standardOutput = stdout
-    }
-    def longTag = stdout.toString().trim()
-
-    return longTag.substring(longTag.indexOf('/') + 1, longTag.indexOf('-'))
-
-}
-
 android {
     compileSdkVersion 28
     defaultConfig.minSdkVersion 14

--- a/lifecyklelog/build.gradle
+++ b/lifecyklelog/build.gradle
@@ -5,9 +5,26 @@ apply from: 'bintray.gradle'
 apply from: '../jacoco.gradle'
 apply from: '../ktlint.gradle'
 
+def getVersionTag = {
+    def stdout
+    stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags'
+        standardOutput = stdout
+    }
+    def longTag = stdout.toString().trim()
+
+    return longTag.substring(longTag.indexOf('/') + 1, longTag.indexOf('-'))
+
+}
+
 android {
     compileSdkVersion 28
     defaultConfig.minSdkVersion 14
+
+    defaultConfig {
+        resValue "string", "library_Lifecyklelog_libraryVersion", "${getVersionTag()}"
+    }
 }
 
 dependencies {

--- a/lifecyklelog/src/main/res/values/library_info.xml
+++ b/lifecyklelog/src/main/res/values/library_info.xml
@@ -3,7 +3,7 @@
     <string name="define_Lifecyklelog" translatable="false" ></string>
     <string name="library_Lifecyklelog_author" translatable="false" >Chesire</string>
     <string name="library_Lifecyklelog_authorWebsite" translatable="false" >https://github.com/Chesire</string>
-    <string name="library_Lifecyklelog_libraryName" translatable="false" >Lifecyklelog</string>
+    <string name="library_Lifecyklelog_libraryName" translatable="false" >LifecykleLog</string>
     <string name="library_Lifecyklelog_libraryDescription" translatable="false" >Library to easily log out Android lifecycle methods for Activities and Fragments.</string>
     <string name="library_Lifecyklelog_libraryWebsite" translatable="false" >https://github.com/Chesire/LifecykleLog</string>
     <string name="library_Lifecyklelog_licenseId" translatable="false" >mit</string>

--- a/lifecyklelog/src/main/res/values/library_info.xml
+++ b/lifecyklelog/src/main/res/values/library_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="define_Lifecyklelog" translatable="false" ></string>
+    <string name="library_Lifecyklelog_author" translatable="false" >Chesire</string>
+    <string name="library_Lifecyklelog_authorWebsite" translatable="false" >https://github.com/Chesire</string>
+    <string name="library_Lifecyklelog_libraryName" translatable="false" >Lifecyklelog</string>
+    <string name="library_Lifecyklelog_libraryDescription" translatable="false" >Library to easily log out Android lifecycle methods for Activities and Fragments.</string>
+    <string name="library_Lifecyklelog_libraryWebsite" translatable="false" >https://github.com/Chesire/LifecykleLog</string>
+    <string name="library_Lifecyklelog_licenseId" translatable="false" >mit</string>
+    <string name="library_Lifecyklelog_isOpenSource" translatable="false" >true</string>
+    <string name="library_Lifecyklelog_repositoryLink" translatable="false" >https://github.com/Chesire/LifecykleLog</string>
+</resources>


### PR DESCRIPTION
Include additional string resources for use by AboutLibraries to display
information about this library when included as a project dependency.

This change follows the guidelines [here](https://github.com/mikepenz/AboutLibraries/wiki/HOWTODEV:-Include-in-your-library) and has been tested by including the project as a submodule in AboutLibraries.

![image](https://user-images.githubusercontent.com/8459796/66080449-0aa85000-e55e-11e9-8b1b-87435e795407.png)
