### PR TITLE
fix: trying to get the tag while on a tag fails

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,5 +57,9 @@ ext.getVersionTag = {
     }
     def longTag = stdout.toString().trim()
 
-    return longTag.substring(longTag.indexOf('/') + 1, longTag.indexOf('-'))
+    if (longTag.contains('-')) {
+        return longTag.substring(longTag.indexOf('/') + 1, longTag.indexOf('-'))
+    } else {
+        return longTag
+    }
 }


### PR DESCRIPTION
While on a tagged commit, the getVersionTag gradle task is failing due to there not being a `-` in 
the output. Check if the output contains a `-` before substringing, if it doesn't exist then just 
return the full tag