### PR TITLE
chore: default to version 0.0.0 for bintray

### DIFF
--- a/lifecyklelog/bintray.gradle
+++ b/lifecyklelog/bintray.gradle
@@ -5,7 +5,7 @@ publish {
     repoName = 'LifecykleLog'
     groupId = 'com.chesire'
     artifactId = 'lifecyklelog'
-    publishVersion = '2.0.0'
+    publishVersion = '0.0.0'
     desc = 'Android library for logging out Activity and Fragment lifecycle methods.'
     website = 'https://github.com/Chesire/LifecykleLog'
 }


### PR DESCRIPTION
When pushing the library update to bintray, the tag should be supplied via the command line args, 
instead of having to update it manually each time