### PR TITLE
chore: update the target and compile sdks to 29

### DIFF
--- a/lifecyklelog-sample/build.gradle
+++ b/lifecyklelog-sample/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "com.chesire.lifecyklelogsample"
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }

--- a/lifecyklelog/build.gradle
+++ b/lifecyklelog/build.gradle
@@ -5,7 +5,7 @@ apply from: 'bintray.gradle'
 apply from: '../jacoco.gradle'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig.minSdkVersion 14
 
     defaultConfig {


### PR DESCRIPTION
The latest should be targeted for builds, so update to 29