### PR TITLE
chore: update to latest sdk

### DIFF
--- a/lifecyklelog-sample/build.gradle
+++ b/lifecyklelog-sample/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "com.chesire.lifecyklelogsample"
         minSdkVersion 14
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
     }

--- a/lifecyklelog/build.gradle
+++ b/lifecyklelog/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply from: '../jacoco.gradle'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     defaultConfig.minSdkVersion 14
 
     defaultConfig {

--- a/lifecyklelog/src/main/java/com/chesire/lifecyklelog/events/ActivityEvents.kt
+++ b/lifecyklelog/src/main/java/com/chesire/lifecyklelog/events/ActivityEvents.kt
@@ -42,7 +42,7 @@ internal object ActivityEvents : Application.ActivityLifecycleCallbacks {
         LifecykleLog.logLifecycle(activity, LifecycleEvent.ON_DESTROY)
     }
 
-    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle?) {
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
         LifecykleLog.logLifecycle(activity, LifecycleEvent.ON_SAVE_INSTANCE_STATE, outState)
     }
 }

--- a/lifecyklelog/src/test/java/com/chesire/lifecyklelog/events/ActivityEventsTests.kt
+++ b/lifecyklelog/src/test/java/com/chesire/lifecyklelog/events/ActivityEventsTests.kt
@@ -103,15 +103,6 @@ class ActivityEventsTests {
     }
 
     @Test
-    fun `onActivitySaveInstanceState logs the activity with ON_SAVE_INSTANCE_STATE lifecycle event`() {
-        val mockActivity = mockk<Activity>()
-
-        ActivityEvents.onActivitySaveInstanceState(mockActivity, null)
-
-        verify { LifecykleLog.logLifecycle(mockActivity, LifecycleEvent.ON_SAVE_INSTANCE_STATE) }
-    }
-
-    @Test
     fun `onActivitySaveInstanceState logs the activity with ON_SAVE_INSTANCE_STATE lifecycle event with bundle`() {
         val mockBundle = mockk<Bundle>()
         val mockActivity = mockk<Activity>()


### PR DESCRIPTION
Update to version 30 of the target and compile sdks. Only new functionality seems to be that `onActivitySaveInstanceState` event has a non-null bundle now.