### PR TITLE
chore: remove the deprecated kotlin-android-extensions

### DIFF
--- a/lifecyklelog-sample/build.gradle
+++ b/lifecyklelog-sample/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 29

--- a/lifecyklelog/build.gradle
+++ b/lifecyklelog/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply from: '../jacoco.gradle'
 
 android {


### PR DESCRIPTION
Remove the plugin as it was deprecated, and was not needed in the project.