### PR TITLE
ci: replace set-env with env file

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -123,4 +123,4 @@ jobs:
     - name: Set env
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     - name: Deploy
-      run: ./gradlew deploy -PbintrayUser=${{ secrets.BINTRAY_USER_ID }} -PbintrayKey=${{ secrets.BINTRAY_API_KEY }} -PpublishVersion=${{ $RELEASE_VERSION }}
+      run: ./gradlew deploy -PbintrayUser=${{ secrets.BINTRAY_USER_ID }} -PbintrayKey=${{ secrets.BINTRAY_API_KEY }} -PpublishVersion=$RELEASE_VERSION


### PR DESCRIPTION
GitHub actions has deprecated set-env, so replace it with env file